### PR TITLE
lsyncd: trim whitespace and fix syntax in template

### DIFF
--- a/lsyncd/lsyncd.conf.lua.jinja
+++ b/lsyncd/lsyncd.conf.lua.jinja
@@ -11,16 +11,16 @@ settings {
 }
 
 targetlist = {
-{% for target in salt['pillar.get']('lsyncd:targets', '') %}
+{% for target in salt['pillar.get']('lsyncd:targets', '') -%}
     "{{ target }}:{{ lsyncd_target_directory }}",
-{% endfor %}
+{% endfor -%}
 }
 
 for _, server in ipairs(targetlist) do
     sync {
         default.rsync,
         source="{{ lsyncd_source_directory }}",
-        target=server
+        target=server,
         rsync = {
             compress = true,
             acls = true,


### PR DESCRIPTION
The whitespace in the targetlist is aesthetic, the comma in the sync
stanza is required for syntax.
